### PR TITLE
Always return vectors of attributes [consistency]

### DIFF
--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -41,10 +41,10 @@
    the objectClass attribute to a set."
   [attr]
   (let [k (keyword (.getName attr))]
-    (cond
-      (= :objectClass k)     [k (set (vec (.getValues attr)))]
-      (> (.size attr) 1)     [k (vec (.getValues attr))]
-      :else                  [k (.getValue attr)])))
+    (if
+      (= :objectClass k)
+      [k (set (vec (.getValues attr)))]
+      [k (vec (.getValues attr))])))
 
 (defn- entry-as-map
   "Converts an Entry object into a map optionally adding the DN"


### PR DESCRIPTION
I changed the function extract-attribute to always return a vector of values.
Before this change, the function would check for the special case of exactly 1 value, in which
case it would just return the value itself. This cause inconsistency in attributes that
are normally arrays (e.g. a person's direct reports) but can sometimes have only a single member (e.g. a person with only one employee).
