### PR TITLE
Bugfix create modification

### DIFF
--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -200,7 +200,7 @@
   (cond
     (coll? values)    (Modification. modify-op attribute (into-array values))
     (= :all values)   (Modification. modify-op attribute)
-    :else             (Modification. modify-op attribute (str values))))
+    :else             (Modification. modify-op attribute values)))
 
 (defn- modify-ops
   "Returns a sequence of Modification objects to do the given operation

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -74,7 +74,7 @@
   "Adds the values contained in given response control to the given map"
   [m control]
   (condp instance? control
-    PreReadResponseControl 
+    PreReadResponseControl
     (update-in m [:pre-read] merge (entry-as-map (.getEntry control) false))
     PostReadResponseControl
     (update-in m [:post-read] merge (entry-as-map (.getEntry control) false))
@@ -251,8 +251,8 @@
   (if-let [n (.nextEntry source)]
     (cons n (lazy-seq (entry-seq source)))))
 
-;; Extended version of search-results function using a 
-;; SearchRequest that uses a SimplePagedResultsControl.  
+;; Extended version of search-results function using a
+;; SearchRequest that uses a SimplePagedResultsControl.
 ;; Allows us to read arbitrarily large result sets.
 ;; TODO make this lazy
 (defn- search-all-results
@@ -268,15 +268,15 @@
       (.setControls req (list (SimplePagedResultsControl. sizeLimit cookie)))
       (let [res (.search connection req)
             control (SimplePagedResultsControl/get res)
-            newres (->> (.getSearchEntries res) 
-                     (map entry-as-map) 
-                     (remove empty?) 
+            newres (->> (.getSearchEntries res)
+                     (map entry-as-map)
+                     (remove empty?)
                      (into results))]
         (if (and
               (not-nil? control)
               (> (.getValueLength (.getCookie control)) 0))
           (recur newres (.getCookie control))
-          (seq newres)))))) 
+          (seq newres))))))
 
 (defn- search-results
   "Returns a sequence of search results for the given search criteria."
@@ -351,7 +351,7 @@
                     JKS format file, optional, defaults to trusting all
                     certificates
    :connect-timeout The timeout for making connections (milliseconds),
-                    defaults to 1 minute   
+                    defaults to 1 minute
    :timeout         The timeout when waiting for a response from the server
                     (milliseconds), defaults to 5 minutes
    "
@@ -375,7 +375,7 @@ If an LDAP connection pool object is passed as the connection argument
 the bind attempt will have no side-effects, leaving the state of the
 underlying connections unchanged."
   [connection bind-dn password]
-  (try 
+  (try
     (let [bind-result (.bind connection bind-dn password)]
       (if (= ResultCode/SUCCESS (.getResultCode bind-result)) true false))
     (catch Exception _ false)))
@@ -438,7 +438,7 @@ returned either before or after the modifications have taken place."
    the password of the currently-authenticated user, or another user if their
    DN is provided and the caller has the required authorisation."
   ([connection new]
-    (let [request (PasswordModifyExtendedRequest. new)] 
+    (let [request (PasswordModifyExtendedRequest. new)]
       (.processExtendedOperation connection request)))
 
   ([connection old new]
@@ -516,4 +516,3 @@ returned either before or after the modifications have taken place."
                         (search-criteria base options)
                         queue-size
                         f))))
-

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -194,13 +194,28 @@
   (doseq [[k v] m]
     (set-entry-kv! entry-obj k v)))
 
+(defn- byte-array?
+  [v]
+  (= (type v) (type (byte-array 0))))
+
 (defn- create-modification
   "Creates a modification object"
   [modify-op attribute values]
   (cond
-    (coll? values)    (Modification. modify-op attribute (into-array values))
-    (= :all values)   (Modification. modify-op attribute)
-    :else             (Modification. modify-op attribute values)))
+   (and (coll? values) (byte-array? (first values)))
+   (Modification. modify-op attribute (into-array values))
+
+   (coll? values)
+   (Modification. modify-op attribute (into-array String (map str values)))
+
+   (= :all values)
+   (Modification. modify-op attribute)
+
+   (byte-array? values)
+   (Modification. modify-op attribute values)
+
+   :else
+   (Modification. modify-op attribute (str values))))
 
 (defn- modify-ops
   "Returns a sequence of Modification objects to do the given operation


### PR DESCRIPTION
Calling `str` on the value of a modification breaks some updates (e.g. when the value is a byte array). This patch removes the `str` call from single-valued attribute modification, making it consistent with the multi-valued case.