### PR TITLE
Ensure bind? calls against connection pools leave connections unchanged

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Clojure ldap client (development fork of alienscience's clj-ldap)."
   :url "https://github.com/pauldorman/clj-ldap"
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [com.unboundid/unboundid-ldapsdk "2.3.0"]]
+                 [com.unboundid/unboundid-ldapsdk "3.1.0"]]
   :dev-dependencies [[jline "0.9.94"]
                      [org.apache.directory.server/apacheds-all "1.5.5"]
                      [fs "1.1.2"]
@@ -13,4 +13,3 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"})
-

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -377,13 +377,10 @@ the bind attempt will have no side-effects, leaving the state of the
 underlying connections unchanged."
   [connection bind-dn password]
   (try
-    (let [cp? (instance? LDAPConnectionPool connection)
-          c (if cp? (.getConnection connection) connection)]
-      (try
-        (let [r (.bind c bind-dn password)]
-          (= ResultCode/SUCCESS  (.getResultCode r)))
-        (catch LDAPException _ false)
-        (finally (if cp? (.releaseDefunctConnection connection c)))))
+    (let [r (if (instance? LDAPConnectionPool connection)
+              (.bindAndRevertAuthentication connection bind-dn password nil)
+              (.bind connection bind-dn password))]
+      (= ResultCode/SUCCESS (.getResultCode r)))
     (catch Exception _ false)))
 
 (defn get


### PR DESCRIPTION
Without an explicit release connections from connection pools will keep the new binding. This can cause errors, especially when the bind fails.

For example, running the following in the REPL (with appropriate substitutions) will result in an exception being raised on the second call to `get-then-bind` because the previous bind will have left the connection in an invalid state:

```clojure
    (require '[clj-ldap.client :as ldap])

    (let [get-then-bind (fn [c dn pw]
                          (let [u (ldap/get c dn)]
                            (ldap/bind? c dn pw)))
          c (ldap/connect {:host ["localhost:389"]
                           :bind-dn "cn=A User,ou=Users,dc=example,dc=com"
                           :password "password"})
          dn "cn=An Example,ou=Users,dc=example,dc=com"
          fail-pw "aksjdlajl"]
      (do (get-then-bind c dn fail-pw)
          (get-then-bind c dn fail-pw)))
````

Per the [Unboundid LDAP SDK documentation for bind][bind-docs]:

> Note that this will impact the state of the connection in the pool, and therefore this method should only be used if this connection pool is used exclusively for processing bind operations, or if the retain identity request control (only available in the Commercial Edition of the LDAP SDK for use with the UnboundID Directory Server) is included in the bind request to ensure that the authentication state is not impacted.

[bind-docs]: https://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/AbstractConnectionPool.html#bind(com.unboundid.ldap.sdk.BindRequest)

This patch ensures that the `bind?` method adheres to the contract expressed by the documentation (leaves connection pool connection state unchanged.)