### PR TITLE
And test coverage of pre and post-read options, fix a few typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.12]
+This release adds the following:
+- The :proxied-auth option to most functions
+- The compare? function which invokes LDAP compare operation
+- 
 ## [0.0.11]
 This release addresses a bug introduced in 0.0.10 and bumps the ldap-sdk version to 3.1.1.
 - Fix bug preventing use of :pre-read and :post-read options to modify and delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.11]
+This release addresses a bug introduced in 0.0.10 and bumps the ldap-sdk version to 3.1.1.
+- Fix bug preventing use of :pre-read and :post-read options to modify and delete
+- Introduce test coverage of :pre-read and :post-read
+
 ## [0.0.10]
 ### Binary (byte-array) attribute values
 The behavior of the api towards binary valued attributes has been fixed. Thanks to Ray Miller for providing the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This release adds the following:
 - The :proxied-auth option to most functions
 - The compare? function which invokes LDAP compare operation
-- 
+
 ## [0.0.11]
 This release addresses a bug introduced in 0.0.10 and bumps the ldap-sdk version to 3.1.1.
 - Fix bug preventing use of :pre-read and :post-read options to modify and delete

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Determines if the specified entry contains the given attribute and value.
     (ldap/compare? conn "cn=dude,ou=people,dc=example,dc=com"
                    :description "His dudeness")
 ```
-Throws a [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if there is an error with the request or the add failed.
+Throws a [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if there is an error with the request or the LDAP compare failed.
 
 ## modify [connection dn modifications]                    
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 clj-ldap is a thin layer on the [unboundid sdk](http://www.unboundid.com/products/ldap-sdk/) and allows clojure programs to talk to ldap servers. This library is available on [clojars.org](http://clojars.org/search?q=clj-ldap)
 ```clojure
-     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.11"]]
+     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.12"]]
 ```
 # Example 
 
@@ -110,6 +110,16 @@ Adds an entry to the connected ldap server. The entry is map of keywords to valu
 ```
 Throws a [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if there is an error with the request or the add failed.
 
+## compare? [connection dn attribute assertion-value]
+
+Determines if the specified entry contains the given attribute and value.
+
+```clojure
+    (ldap/compare? conn "cn=dude,ou=people,dc=example,dc=com"
+                   :description "His dudeness")
+```
+Throws a [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if there is an error with the request or the add failed.
+
 ## modify [connection dn modifications]                    
 
 Modifies an entry in the connected ldap server. The modifications are
@@ -142,7 +152,8 @@ All the keys in the map are optional e.g:
 The values in the map can also be set to :all when doing a delete e.g:
 ```clojure
      (ldap/modify conn "cn=dude,ou=people,dc=example,dc=com"
-                  {:delete {:telephoneNumber :all}})
+                  {:delete {:telephoneNumber :all}}
+                  {:proxied-auth "dn:cn=app,dc=example,dc=com"})
 ```
 The values of the attributes given in :pre-read and :post-read are available in the returned map and are part of an atomic ldap operation e.g
 ```clojure
@@ -186,6 +197,8 @@ Options is a map with the following optional entries:
                    :sort-keys [ :cn :ascending
                                 :employeNumber :descending ... ] }
                  At least one sort key must be provided.
+    :proxied-auth    The dn:<dn> or u:<uid> to be used as the authorization
+                     identity when processing the request. Don't forget the dn:/u: prefix.
     :controls    Adds the provided controls for this request.
     :respf       Applies this function to the list of response controls present.
 
@@ -193,7 +206,8 @@ e.g
 ```clojure
     (ldap/search conn "ou=people,dc=example,dc=com")
     
-    (ldap/search conn "ou=people,dc=example,dc=com" {:attributes [:cn] :sizelimit 100})
+    (ldap/search conn "ou=people,dc=example,dc=com" {:attributes [:cn] :sizelimit 100
+                                                     :proxied-auth "dn:cn=app,dc=example,dc=com"})
 
     (ldap/search conn "dc=example,dc=com" {:filter "(uid=abc123)" :attributes [:cn :uid :userCertificate]
                                            :byte-valued [:userCertificate]})

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Options is a map with the following entries:
 Throws an [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if an error occurs establishing the connection pool or authenticating to any of the servers.
 Some examples:
 ```clojure
-    (ldap/connect conn {:host "ldap.example.com" :num-connections 10})
+    (ldap/connect {:host "ldap.example.com" :num-connections 10})
     
-    (ldap/connect conn {:host [{:address "ldap1.example.com" :port 1389}
-                               {:address "ldap3.example.com"}
-                               "ldap2.example.com:1389"]
-                        :ssl? true
-                        :num-connections 9})
+    (ldap/connect {:host [{:address "ldap1.example.com" :port 1389}
+                          {:address "ldap3.example.com"}
+                          "ldap2.example.com:1389"]
+                   :startTLS? true
+                   :num-connections 9})
                         
-    (ldap/connect conn {:host {:port 1389}})
+    (ldap/connect {:host {:port 1389}})
 ```
 
 ## bind? [connection bind-dn password] [connection-pool bind-dn password]
@@ -150,7 +150,7 @@ The values of the attributes given in :pre-read and :post-read are available in 
                   {:increment {:uidNumber 1}
                    :post-read #{:uidNumber}})
 ```
-     returns
+returns
 ```clojure
        {:code 0
         :name "success"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 clj-ldap is a thin layer on the [unboundid sdk](http://www.unboundid.com/products/ldap-sdk/) and allows clojure programs to talk to ldap servers. This library is available on [clojars.org](http://clojars.org/search?q=clj-ldap)
 ```clojure
-     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.10"]]
+     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.11"]]
 ```
 # Example 
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject org.clojars.pntblnk/clj-ldap "0.0.10"
+(defproject org.clojars.pntblnk/clj-ldap "0.0.11"
   :description "Clojure ldap client."
   :url "https://github.com/pauldorman/clj-ldap"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.unboundid/unboundid-ldapsdk "3.1.0"]]
+                 [com.unboundid/unboundid-ldapsdk "3.1.1"]]
   :profiles {:test {:dependencies [[lein-clojars "0.9.1"]]}}
   :aot [clj-ldap.client]
   :license {:name "Eclipse Public License - v 1.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.pntblnk/clj-ldap "0.0.11"
+(defproject org.clojars.pntblnk/clj-ldap "0.0.12"
   :description "Clojure ldap client."
   :url "https://github.com/pauldorman/clj-ldap"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -106,11 +106,11 @@
   [m control]
   (condp instance? control
     PreReadResponseControl
-    (update-in m [:pre-read] merge ((entry-as-map [])
-                                     (.getEntry control) false))
+    (update-in m [:pre-read] merge ((entry-as-map [] false)
+                                     (.getEntry control)))
     PostReadResponseControl
-    (update-in m [:post-read] merge ((entry-as-map [])
-                                      (.getEntry control) false))
+    (update-in m [:post-read] merge ((entry-as-map [] false)
+                                      (.getEntry control)))
     m))
 
 (defn- add-response-controls

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -147,14 +147,20 @@
          success*))
   (is (= (:changeNumber (ldap/get *conn* (str "changeNumber=1234," base*)))
          "1234"))
-  (is (= (ldap/delete *conn* (str "changeNumber=1234," base*))
-         success*)))
+  (is (= (ldap/delete *conn* (str "changeNumber=1234," base*)
+                      {:pre-read [:objectClass]})
+         {:code 0, :name "success",
+          :pre-read {:objectClass #{"top" "changeLogEntry"}}})))
 
 (deftest test-modify-add
   (is (= (ldap/modify *conn* (:dn person-a*)
                       {:add {:objectClass "organizationalPerson"
-                             :l "Hollywood"}})
-         success*))
+                             :l "Hollywood"}
+                       :pre-read #{:objectClass :l :cn}
+                       :post-read #{:l :cn}})
+         {:code 0, :name "success",
+          :pre-read {:objectClass #{"top" "person"}, :cn "testa"},
+          :post-read {:l "Hollywood", :cn "testa"}}))
   (is (= (ldap/modify
           *conn* (:dn person-b*)
           {:add {:telephoneNumber ["0000000005" "0000000006"]}})

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -207,7 +207,8 @@
     (is (= (ldap/modify *conn* (:dn person-a*)
                         {:add {:objectclass ["inetOrgPerson"
                                              "organizationalPerson"]
-                               :userCertificate certificate-data}})
+                               :userCertificate certificate-data}}
+                        {:proxied-auth (str "dn:" (:dn person-a*))})
            success*))
     (is (= (seq (:userCertificate
                   (first (ldap/search *conn* (:dn person-a*)
@@ -245,7 +246,9 @@
          (set [nil "testa" "testb" "Saul Hazledine"])))
   (is (= (set (map :cn
                    (ldap/search *conn* base*
-                                {:attributes [:cn] :filter "cn=test*"})))
+                                {:attributes [:cn]
+                                 :filter     "cn=test*"
+                                 :proxied-auth  (str "dn:" (:dn person-a*))})))
          (set ["testa" "testb"])))
   (is (= (map :cn
               (ldap/search *conn* base*
@@ -276,3 +279,12 @@
     (is (= *side-effects*
            (set [{:cn "testa" :sn "a"}
                  {:cn "testb" :sn "b"}])))))
+
+(deftest test-compare?
+  (is (= (ldap/compare? *conn* (:dn person-b*)
+                        :description "István Orosz")
+         true))
+  (is (= (ldap/compare? *conn* (:dn person-a*)
+                        :description "István Orosz"
+                        {:proxied-auth (str "dn:" (:dn person-b*))})
+         false)))


### PR DESCRIPTION
- Add test coverage for pre and post-read options to modify and delete
- The ldap/connect examples were incorrect.