### PR TITLE
Fix :pre- & :post-read for response

### DIFF
--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -103,11 +103,11 @@
   [m control]
   (condp instance? control
     PreReadResponseControl
-    (update-in m [:pre-read] merge ((entry-as-map [])
-                                     (.getEntry control) false))
+    (update-in m [:pre-read] merge ((entry-as-map [] false)
+                                     (.getEntry control)))
     PostReadResponseControl
-    (update-in m [:post-read] merge ((entry-as-map [])
-                                      (.getEntry control) false))
+    (update-in m [:post-read] merge ((entry-as-map [] false)
+                                      (.getEntry control)))
     m))
 
 (defn- add-response-controls


### PR DESCRIPTION
entry-as-map returns a function that takes only one argument. The error was that the second argument (a boolean) for entry-as-map was passed to the returned function with an arity of one.