### PR TITLE
allow recursive deletion of an entire subtree

### DIFF
--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -42,7 +42,8 @@
             ProxiedAuthorizationV2RequestControl
             SimplePagedResultsControl
             ServerSideSortRequestControl
-            SortKey])
+            SortKey
+            SubtreeDeleteRequestControl])
   (:import [com.unboundid.util
             Base64])
   (:import [com.unboundid.util.ssl
@@ -294,7 +295,9 @@
       (.addControl request pre-read-control)))
   (when (contains? options :proxied-auth)
     (.addControl request (ProxiedAuthorizationV2RequestControl.
-                           (:proxied-auth options)))))
+                           (:proxied-auth options))))
+  (when (and (contains? options :recursive) (= (type request) DeleteRequest))
+    (.addControl request (SubtreeDeleteRequestControl.))))
 
 (defn- get-modify-request
   "Sets up a ModifyRequest object using the contents of the given map"
@@ -661,15 +664,16 @@ returned either before or after the modifications have taken place."
    a map that can contain:
       :pre-read     Indicates the attributes that should be read before deletion
       :proxied-auth The dn:<dn> or u:<uid> to be used as the authorization
-                    identity when processing the request."
+                    identity when processing the request.
+      :recursive    Whether or not to recursively delete the subtree"
   ([connection dn]
-     (delete connection dn nil))
+   (delete connection dn nil))
   ([connection dn options]
-     (let [delete-obj (DeleteRequest. dn)]
-       (when options
-         (add-request-controls delete-obj options))
-       (ldap-result
-        (.delete connection delete-obj)))))
+   (let [delete-obj (DeleteRequest. dn)]
+     (when options
+       (add-request-controls delete-obj options))
+     (ldap-result
+      (.delete connection delete-obj)))))
 
 ;; For the following search functions.
 ;; Options is a map with the following optional entries:

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -296,7 +296,7 @@
   (when (contains? options :proxied-auth)
     (.addControl request (ProxiedAuthorizationV2RequestControl.
                            (:proxied-auth options))))
-  (when (and (contains? options :recursive) (= (type request) DeleteRequest))
+  (when (and (contains? options :delete-subtree) (= (type request) DeleteRequest))
     (.addControl request (SubtreeDeleteRequestControl.))))
 
 (defn- get-modify-request
@@ -662,10 +662,12 @@ returned either before or after the modifications have taken place."
 (defn delete
   "Deletes the given entry in the connected ldap server. Optionally takes
    a map that can contain:
-      :pre-read     Indicates the attributes that should be read before deletion
-      :proxied-auth The dn:<dn> or u:<uid> to be used as the authorization
-                    identity when processing the request.
-      :recursive    Whether or not to recursively delete the subtree"
+      :pre-read        Indicates the attributes that should be read before
+                       deletion
+      :proxied-auth    The dn:<dn> or u:<uid> to be used as the authorization
+                       identity when processing the request.
+      :delete-subtree  If truthy, deletes the entire subtree of DN (server must
+                       support Subtree Delete Control, 1.2.840.113556.1.4.805)"
   ([connection dn]
    (delete connection dn nil))
   ([connection dn options]

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -120,7 +120,7 @@
         (catch Exception e))
       (f)
       (try
-        (ldap/delete *conn* toplevel* {:recursive true})
+        (ldap/delete *conn* toplevel* {:delete-subtree true})
         (catch Exception e)))))
 
 (use-fixtures :each test-data)
@@ -169,11 +169,12 @@
          {:code 0, :name "success",
           :pre-read {:objectClass #{"top" "changeLogEntry"}}})))
 
-(deftest test-recursive-delete
+(deftest test-delete-subtree
   (is (= (ldap/add *conn* (:dn person-c*) (:object person-c*))
          success*))
-  (is (= (ldap/delete *conn* base* {:recursive true})
-         success*)))
+  (is (= (ldap/delete *conn* base* {:delete-subtree true})
+         success*))
+  (is (nil? (ldap/get *conn* base*))))
 
 (deftest test-modify-add
   (is (= (ldap/modify *conn* (:dn person-a*)

--- a/test/clj_ldap/test/server.clj
+++ b/test/clj_ldap/test/server.clj
@@ -50,22 +50,6 @@
     (.startListening ds)
     ds))
 
-(defn- add-toplevel-objects!
-  "Adds top level entries, needed for testing, to the ldap server"
-  [connection]
-  (ldap/add connection "dc=alienscience,dc=org,dc=uk"
-            {:objectClass ["top" "domain" "extensibleObject"]
-             :dc "alienscience"})
-  (ldap/add connection "ou=people,dc=alienscience,dc=org,dc=uk"
-            {:objectClass ["top" "organizationalUnit"]
-             :ou "people"})
-  (ldap/add connection
-            "cn=Saul Hazledine,ou=people,dc=alienscience,dc=org,dc=uk"
-            {:objectClass ["top" "Person"]
-             :cn "Saul Hazledine"
-             :sn "Hazledine"
-             :description "Creator of bugs"}))
-
 (defn stop!
   "Stops the embedded ldap server (listening on LDAP and LDAPS ports)"
   []
@@ -86,6 +70,4 @@
   "Starts an embedded ldap server on the given port and SSL"
   []
   (stop!)
-  (reset! server (start-ldap-server))
-  (let [conn (.getConnection @server)]
-    (add-toplevel-objects! conn)))
+  (reset! server (start-ldap-server)))


### PR DESCRIPTION
This uses the [SubtreeDeleteRequestControl](https://docs.ldap.com/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/controls/SubtreeDeleteRequestControl.html) by optionally specifying `{:recursive true}` on a delete.

I moved around the toplevel entries from the server file in the tests to the client side (so that they get recreated for every test).