### PR TITLE
Doc and test update for delete subtree, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 clj-ldap is a thin layer on the [unboundid sdk](http://www.unboundid.com/products/ldap-sdk/) and allows clojure programs to talk to ldap servers. This library is available on [clojars.org](http://clojars.org/search?q=clj-ldap)
 ```clojure
-     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.12"]]
+     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.13"]]
 ```
 # Example 
 
@@ -251,11 +251,18 @@ Throws a [LDAPSearchException](http://www.unboundid.com/products/ldap-sdk/docs/j
 
 ## delete [connection dn] [connection dn options]
 
-Deletes the given entry in the connected ldap server. Optionally takes a map that can contain the entry :pre-read to indicate the attributes that should be read before deletion.
+Deletes the given entry in the connected ldap server.
+
+Options is a map with the following optional entries:
+
+    :delete-subtree  Use the Subtree Delete Control to delete entire subtree rooted at dn.
+    :pre-read        A set of attributes that should be read before deletion (will only apply to base entry if used with :delete-subtree).
+    :proxied-auth    The dn:<dn> or u:<uid> to be used as the authorization
+                     identity when processing the request. Don't forget the dn:/u: prefix.
 ```clojure
      (ldap/delete conn "cn=dude,ou=people,dc=example,dc=com")
 
      (ldap/delete conn "cn=dude,ou=people,dc=example,dc=com" 
-                       {:pre-read #{"telephoneNumber"}})
+                       {:pre-read #{:telephoneNumber}})
 ```
 Throws a [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if the object does not exist or an error occurs.

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject org.clojars.pntblnk/clj-ldap "0.0.12"
+(defproject org.clojars.pntblnk/clj-ldap "0.0.13"
   :description "Clojure ldap client."
   :url "https://github.com/pauldorman/clj-ldap"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.unboundid/unboundid-ldapsdk "3.1.1"]]
+                 [com.unboundid/unboundid-ldapsdk "3.2.0"]]
   :profiles {:test {:dependencies [[lein-clojars "0.9.1"]]}}
   :aot [clj-ldap.client]
   :license {:name "Eclipse Public License - v 1.0"

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -662,8 +662,8 @@ returned either before or after the modifications have taken place."
 (defn delete
   "Deletes the given entry in the connected ldap server. Optionally takes
    a map that can contain:
-      :pre-read        Indicates the attributes that should be read before
-                       deletion
+      :pre-read        A set of attributes that should be read before deletion
+                       (only applied to base entry if used with :delete-subtree)
       :proxied-auth    The dn:<dn> or u:<uid> to be used as the authorization
                        identity when processing the request.
       :delete-subtree  If truthy, deletes the entire subtree of DN (server must

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -95,14 +95,14 @@
 (defn- add-toplevel-objects!
   "Adds top level entries, needed for testing, to the ldap server"
   [connection]
-  (ldap/add connection "dc=alienscience,dc=org,dc=uk"
+  (ldap/add connection toplevel*
             {:objectClass ["top" "domain" "extensibleObject"]
              :dc "alienscience"})
-  (ldap/add connection "ou=people,dc=alienscience,dc=org,dc=uk"
+  (ldap/add connection base*
             {:objectClass ["top" "organizationalUnit"]
              :ou "people"})
   (ldap/add connection
-            "cn=Saul Hazledine,ou=people,dc=alienscience,dc=org,dc=uk"
+            (str "cn=Saul Hazledine," base*)
             {:objectClass ["top" "Person"]
              :cn "Saul Hazledine"
              :sn "Hazledine"


### PR DESCRIPTION
Making some doc changes for the :delete-subtree option and bumping the ldap sdk version dependency.