### PR TITLE
feat(connect):support max-connections in pool opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ Throws an [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javado
 Some examples:
 ```clojure
     (ldap/connect {:host "ldap.example.com"
-                   :initial-connections 10
-                   :max-connections 20
+                   :num-connections 4
                    :bind-dn "cn=admin,dc=example,dc=com"
                    :password "password"})
     

--- a/README.md
+++ b/README.md
@@ -33,28 +33,36 @@ clj-ldap is a thin layer on the [unboundid sdk](http://www.unboundid.com/product
 Connects to an ldap server and returns a, thread safe, [LDAPConnectionPool](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPConnectionPool.html).
 Options is a map with the following entries:
 
-    :host            Either a string in the form "address:port"
-                     OR a map containing the keys,
-                        :address   defaults to localhost
-                        :port      defaults to 389 (or 636 for ldaps),
-                     OR a collection containing multiple hosts used for load
-                     balancing and failover. This entry is optional.
-    :bind-dn         The DN to bind as, optional
-    :password        The password to bind with, optional
-    :num-connections The number of connections in the pool, defaults to 1
-    :ssl?            Boolean, connect over SSL (ldaps), defaults to false
-    :startTLS?       Boolean, use startTLS over non-SSL port, defaults to false
-    :trust-store     Only trust SSL certificates that are in this
-                     JKS format file, optional, defaults to trusting all
-                     certificates
-    :connect-timeout The timeout for making connections (milliseconds),
-    :timeout         The timeout when waiting for a response from the server
-                     (milliseconds), defaults to 5 minutes
+    :host                Either a string in the form "address:port"
+                         OR a map containing the keys,
+                            :address   defaults to localhost
+                            :port      defaults to 389 (or 636 for ldaps),
+                         OR a collection containing multiple hosts used for load
+                         balancing and failover. This entry is optional.
+    :bind-dn             The DN to bind as, optional
+    :password            The password to bind with, optional
+    :num-connections     Establish a fixed size connection pool. Defaults to 1.
+    :initial-connections Establish a connection pool initially of this size with
+                         capability to grow to :max-connections. Defaults to 1.
+    :max-connections     Define maximum size of connection pool. It must be 
+                         greater than or equal to the initial number of 
+                         connections, defaults to value of :initial-connections.
+    :ssl?                Boolean, connect over SSL (ldaps), defaults to false
+    :startTLS?           Boolean, use startTLS over non-SSL port, defaults to false
+    :trust-store         Only trust SSL certificates that are in this
+                         JKS format file, optional, defaults to trusting all
+                         certificates
+    :connect-timeout     The timeout for making connections (milliseconds),
+                         defaults to 1 minute
+    :timeout             The timeout when waiting for a response from the server
+                         (milliseconds), defaults to 5 minutes
 
 Throws an [LDAPException](http://www.unboundid.com/products/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPException.html) if an error occurs establishing the connection pool or authenticating to any of the servers.
 Some examples:
 ```clojure
-    (ldap/connect {:host "ldap.example.com" :num-connections 10
+    (ldap/connect {:host "ldap.example.com"
+                   :initial-connections 10
+                   :max-connections 20
                    :bind-dn "cn=admin,dc=example,dc=com"
                    :password "password"})
     
@@ -62,7 +70,8 @@ Some examples:
                           {:address "ldap3.example.com"}
                           "ldap2.example.com:1389"]
                    :startTLS? true
-                   :num-connections 9
+                   :initial-connections 9
+                   :max-connections 18
                    :bind-dn "cn=directory manager"
                    :password "password"})
                         

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -486,7 +486,7 @@
    :initial-connections Establish a connection pool initially of this size with
                         capability to grow to :max-connections. Defaults to 1.
    :max-connections     Define maximum size of connection pool. It must be 
-	                greater than or equal to the initial number of 
+                        greater than or equal to the initial number of 
                         connections, defaults to value of :initial-connections.
    :ssl?                Boolean, connect over SSL (ldaps), defaults to false
    :startTLS?           Boolean, use startTLS over non-SSL port, defaults to false

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -67,16 +67,17 @@
    (ldap/connect {:host {:port port}})
    (ldap/connect {:host {:address "localhost"
                          :port port}
-                  :num-connections 4
-                  :max-connections 4})
+                  :num-connections 4})
    (ldap/connect {:host (str "localhost:" port)})
    (ldap/connect {:ssl? true
-                  :host {:port ssl-port}})
+                  :host {:port ssl-port}
+                  :initial-connections 2})
    (ldap/connect {:starTLS? true
                   :host {:port port}})
    (ldap/connect {:host {:port port}
                   :connect-timeout 1000
-                  :timeout 5000})
+                  :timeout 5000
+                  :max-connections 2})
    (ldap/connect {:host [(str "localhost:" port)
                          {:port ssl-port}]})
    (ldap/connect {:host [(str "localhost:" ssl-port)

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -67,7 +67,8 @@
    (ldap/connect {:host {:port port}})
    (ldap/connect {:host {:address "localhost"
                          :port port}
-                  :num-connections 4})
+                  :num-connections 4
+                  :max-connections 4})
    (ldap/connect {:host (str "localhost:" port)})
    (ldap/connect {:ssl? true
                   :host {:port ssl-port}})
@@ -81,7 +82,8 @@
    (ldap/connect {:host [(str "localhost:" ssl-port)
                          {:port ssl-port}]
                   :ssl? true
-                  :num-connections 5})])
+                  :num-connections 5
+                  :max-connections 10})])
 
 
 (defn- test-server


### PR DESCRIPTION
What this pr do:
- prefer `initial-connections` to `num-connections`
- support `max-connections` in pool opts
- recode `connect-to-host` based on `connect-to-hosts`, using another constructor