### PR TITLE
fixed to not eat the exception when bind fails

### DIFF
--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -537,12 +537,10 @@ If an LDAP connection pool object is passed as the connection argument
 the bind attempt will have no side-effects, leaving the state of the
 underlying connections unchanged."
   [connection bind-dn password]
-  (try
-    (let [r (if (instance? LDAPConnectionPool connection)
-              (.bindAndRevertAuthentication connection bind-dn password nil)
-              (.bind connection bind-dn password))]
-      (= ResultCode/SUCCESS (.getResultCode r)))
-    (catch Exception _ false)))
+  (let [r (if (instance? LDAPConnectionPool connection)
+            (.bindAndRevertAuthentication connection bind-dn password nil)
+            (.bind connection bind-dn password))]
+    (= ResultCode/SUCCESS (.getResultCode r))))
 
 (defn close
   "closes the supplied connection or pool object"


### PR DESCRIPTION
Eating the exception when `bind?` fails makes it difficult to debug what happened. I had a case where incorrect `bind-dn` was provided, and it was not possible to tell what the actual problem was since `bind?` would just return `nil` instead of the error.